### PR TITLE
:sparkles: feat: PrimaryModal 구조 및 ApiKeyView/Confirm variant 추가 (JNII-73)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,31 +1,29 @@
-import {NextIntlClientProvider} from 'next-intl';
-import {getMessages} from 'next-intl/server';
-import {notFound} from 'next/navigation';
-import {routing} from '@/i18n/routing';
-import { ThemeProvider } from '@/contexts/theme-provider';
- 
+import "../globals.css"; // ★ 전역 스타일 추가
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages } from "next-intl/server";
+import { ThemeProvider } from "@/contexts/theme-provider";
+
 export default async function RootLayout({
-  children,
-  params
-}: {
+                                           children,
+                                           params,
+                                         }: {
   children: React.ReactNode;
-  params: Promise<{locale: string}>;
+  params: Promise<{ locale: string }>;
 }) {
-  const {locale} = await params;
- 
-  // 클라이언트에게 모든 메시지를 제공합니다.
-  // side is the easiest way to get started
+  const { locale } = await params;
+
+  // 메시지 불러오기
   const messages = await getMessages();
- 
+
   return (
-    <html lang={locale} suppressHydrationWarning>
+      <html lang={locale} className="dark" suppressHydrationWarning>
       <body>
-        <ThemeProvider>
-          <NextIntlClientProvider messages={messages}>
-            {children}
-          </NextIntlClientProvider>
-        </ThemeProvider>
+      <ThemeProvider>
+        <NextIntlClientProvider messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </ThemeProvider>
       </body>
-    </html>
+      </html>
   );
 }

--- a/src/app/[locale]/modal-playground/page.tsx
+++ b/src/app/[locale]/modal-playground/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React from "react";
+import { PrimaryModal, type PrimaryVariantKey } from "@/components/ui/modal/primary";
+
+export default function ModalPlaygroundPage() {
+    const [open, setOpen] = React.useState(false);
+    const [variant, setVariant] = React.useState<PrimaryVariantKey>("apiKeyView");
+
+    return (
+        <div className="p-6">
+            <button
+                className="rounded-md bg-accent text-black px-4 py-2"
+                onClick={() => setOpen(true)}
+            >
+                Open PrimaryModal
+            </button>
+
+            <PrimaryModal
+                isOpen={open}
+                onClose={() => setOpen(false)}
+                variant={variant}
+            />
+        </div>
+    );
+}

--- a/src/components/ui/modal/BaseModal.tsx
+++ b/src/components/ui/modal/BaseModal.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React, { PropsWithChildren, useEffect } from "react";
+import clsx from "clsx";
+
+type BaseModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    className?: string;
+};
+
+const BaseModal: React.FC<PropsWithChildren<BaseModalProps>> = ({
+                                                                    isOpen,
+                                                                    onClose,
+                                                                    className,
+                                                                    children,
+                                                                }) => {
+    useEffect(() => {
+        if (!isOpen) return;
+        const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={onClose}
+            aria-modal
+            role="dialog"
+        >
+            <div
+                className={clsx("rounded-[28px] shadow-lg", className)}
+                onClick={(e) => e.stopPropagation()}
+            >
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default BaseModal;

--- a/src/components/ui/modal/primary/PrimaryModal.tsx
+++ b/src/components/ui/modal/primary/PrimaryModal.tsx
@@ -1,0 +1,33 @@
+// src/components/ui/modal/primary/PrimaryModal.tsx
+"use client";
+
+import React from "react";
+import BaseModal from "../../modal/BaseModal";
+import { PRIMARY_VARIANTS, type PrimaryVariantKey } from "./registry";
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    variant: PrimaryVariantKey;                 // 어떤 화면을 띄울지
+    initialVariant?: PrimaryVariantKey;         // (선택) 내부 전환 시작점 별도 지정
+};
+
+const PrimaryModal: React.FC<Props> = ({ isOpen, onClose, variant, initialVariant }) => {
+    // 외부 variant가 바뀌면 동기화, 내부 전환(go)도 허용
+    const [current, setCurrent] = React.useState<PrimaryVariantKey>(initialVariant ?? variant);
+    React.useEffect(() => setCurrent(variant), [variant]);
+
+    const Current = PRIMARY_VARIANTS[current];
+
+    return (
+        <BaseModal
+            isOpen={isOpen}
+            onClose={() => { setCurrent(initialVariant ?? variant); onClose(); }} // 닫을 때 초기화
+            className="w-[696px] h-[336px] bg-surface-1 text-white px-10 py-8 flex flex-col justify-between"
+        >
+            <Current onClose={onClose} go={setCurrent} />
+        </BaseModal>
+    );
+};
+
+export default PrimaryModal;

--- a/src/components/ui/modal/primary/index.ts
+++ b/src/components/ui/modal/primary/index.ts
@@ -1,0 +1,3 @@
+// src/components/ui/modal/primary/index.ts
+export { default as PrimaryModal } from "./PrimaryModal";
+export type { PrimaryVariantKey } from "./registry";

--- a/src/components/ui/modal/primary/registry.ts
+++ b/src/components/ui/modal/primary/registry.ts
@@ -1,0 +1,20 @@
+// src/components/ui/modal/primary/registry.ts
+import type { ComponentType } from "react";
+import ApiKeyView from "./variants/ApiKeyView";
+import ApiKeyConfirm from "./variants/ApiKeyConfirm";
+
+// 추후 여기만 추가/수정하면 됨
+export const PRIMARY_VARIANTS = {
+    apiKeyView: ApiKeyView,
+    apiKeyConfirm: ApiKeyConfirm,
+} as const;
+
+export type PrimaryVariantKey = keyof typeof PRIMARY_VARIANTS;
+
+// 공통 props (호스트에서 내려주는 최소 인터페이스)
+export type PrimaryVariantProps = {
+    onClose: () => void;
+    go: (to: PrimaryVariantKey) => void;
+    // 필요시 데이터 추가: e.g. apiKey?: string;
+};
+export type VariantComponent = ComponentType<PrimaryVariantProps>;

--- a/src/components/ui/modal/primary/variants/ApiKeyConfirm.tsx
+++ b/src/components/ui/modal/primary/variants/ApiKeyConfirm.tsx
@@ -1,0 +1,30 @@
+// src/components/ui/modal/primary/variants/ApiKeyConfirm.tsx
+"use client";
+
+import PrimaryButton from "../../../PrimaryButton";
+import type { PrimaryVariantProps } from "../registry";
+
+const ApiKeyConfirm: React.FC<PrimaryVariantProps> = ({ onClose, go }) => {
+    return (
+        <>
+            <h2 className="text-display1">API Key Management</h2>
+
+            <div className="flex-1 flex items-center justify-center">
+                <div className="px-6 py-4 rounded-[12px] bg-surface-2">
+                    <p className="text-title1 text-primary">정말 삭제하시겠습니까?</p>
+                </div>
+            </div>
+
+            <div className="flex justify-end gap-4">
+                <PrimaryButton variant="secondary" size="md" onClick={() => go("apiKeyView")}>
+                    <span className="text-title2">취소</span>
+                </PrimaryButton>
+                <PrimaryButton variant="primary" size="md" onClick={onClose}>
+                    <span className="text-title2">삭제</span>
+                </PrimaryButton>
+            </div>
+        </>
+    );
+};
+
+export default ApiKeyConfirm;

--- a/src/components/ui/modal/primary/variants/ApiKeyView.tsx
+++ b/src/components/ui/modal/primary/variants/ApiKeyView.tsx
@@ -1,0 +1,45 @@
+// src/components/ui/modal/primary/variants/ApiKeyView.tsx
+"use client";
+
+import PrimaryButton from "../../../PrimaryButton";
+import type { PrimaryVariantProps } from "../registry";
+
+const ApiKeyView: React.FC<PrimaryVariantProps> = ({ onClose, go }) => {
+    return (
+        <>
+            {/* 제목 */}
+            <h2 className="text-display1">API Key Management</h2>
+
+            {/* 입력 */}
+            <div className="space-y-2">
+                <p className="text-title2 text-secondary">API key for confirm</p>
+                <div className="flex items-center gap-2">
+                    <input
+                        readOnly
+                        value="90193049dklfkaJfjo94809dsakljfkjd"
+                        className="
+              flex-1 rounded-md
+              bg-surface-2 px-4 py-2
+              text-body3 text-white outline-none
+            "
+                    />
+                    <div className="flex items-center justify-center w-8 h-8 rounded bg-accent">
+                        <span className="text-black font-bold">✓</span>
+                    </div>
+                </div>
+            </div>
+
+            {/* 액션 */}
+            <div className="flex justify-end gap-4">
+                <PrimaryButton variant="secondary" size="md" onClick={() => go("apiKeyConfirm")}>
+                    <span className="text-title2">삭제</span>
+                </PrimaryButton>
+                <PrimaryButton variant="primary" size="md">
+                    <span className="text-title2">수정</span>
+                </PrimaryButton>
+            </div>
+        </>
+    );
+};
+
+export default ApiKeyView;


### PR DESCRIPTION
## 개요
- closed #73
- PrimaryModal 구조 및 ApiKeyView/Confirm variant 추가
- BaseModal로 모달 공통 로직(ESC, 오버레이, 중앙 정렬) 분리
- modal-playground 페이지에서 테스트 가능하도록 구성

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

| 작업 내용            | 이모지 | 코드           | 설명                                        |
| ---------------- | ---- | ------------- | ----------------------------------------- |
| 새로운 기능 추가       | ✨    | `:sparkles:`  | BaseModal 및 PrimaryModal 구조 추가               |
| 새로운 기능 추가       | ✨    | `:sparkles:`  | ApiKeyView / ApiKeyConfirm variant 구현         |
| 새로운 기능 추가       | ✨    | `:sparkles:`  | modal-playground 테스트 페이지 추가                |

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
- Reviewers : -
- Labels : feat, JNII-73
